### PR TITLE
Made from_strip case-insesitive

### DIFF
--- a/ssmtp.c
+++ b/ssmtp.c
@@ -433,7 +433,7 @@ char *from_strip(char *str)
 	(void)fprintf(stderr, "*** from_strip(): str = [%s]\n", str);
 #endif
 
-	if(strncmp("From:", str, 5) == 0) {
+	if(strncasecmp("From:", str, 5) == 0) {
 		str += 5;
 	}
 


### PR DESCRIPTION
if the from-header looks like
"FROM: user@domain.net"
the return-path becomes
"Return-path: <"FROM:user"@domain.net>"

while
"From: user@domain.net"
and
"FROM: <user@domain.net>"
makes
"Return-path: user@domain.net"
