### PR TITLE
Allowing AuthPass to have a '#' char on its value.

### DIFF
--- a/ssmtp.c
+++ b/ssmtp.c
@@ -910,7 +910,7 @@ bool_t read_config()
 		char *begin=buf;
 		char *rightside;
 		/* Make comments invisible */
-		if((p = strchr(buf, '#'))) {
+		if ((p = strip_pre_ws(buf))[0] == '#') {
 			*p = '\0';
 		}
 


### PR DESCRIPTION
There was a bug in the code section that parses ssmtp.conf comments.
It was looking for a '#' anywhere on the current line,
not only at the beginning of it (i.e. "^whitespace then #").

This was rendering passwords in AuthPass blank, which contained '#'
chars.